### PR TITLE
startCmd and endCmd should also apply if not full score

### DIFF
--- a/negativeharmonygenerator.qml
+++ b/negativeharmonygenerator.qml
@@ -240,14 +240,14 @@ MuseScore
         if (fullScore)
         {
             cmd("select-all")
-            curScore.startCmd()
         }
+        curScore.startCmd()
         for (var i in curScore.selection.elements)
             if (curScore.selection.elements[i].pitch)
                 func(curScore.selection.elements[i]);
+        curScore.endCmd();
         if (fullScore)
         {
-            curScore.endCmd();
             cmd("escape");
         }
         Qt.quit();


### PR DESCRIPTION
They make the actions of the things in-between register as one action into the Undo-stack.
endCmd also ensures that changed elements are re-layout in the ScoreView